### PR TITLE
Changes to enable snapshot plugins.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -138,6 +138,17 @@
 		-->
 
 	</properties>
+	
+	<pluginRepositories>
+		<pluginRepository>
+			<id>sonatype-nexus-snapshots</id>
+			<name>Sonatype Nexus Snapshots</name>
+			<url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+			<snapshots>
+				<updatePolicy>always</updatePolicy>
+			</snapshots>
+		</pluginRepository>
+	</pluginRepositories>
 
 	<dependencies>
 		<dependency>


### PR DESCRIPTION
Added in the sonatype snapshot repository that the G2G3 Digital CI pushes the snapshots for master into, hopefully this will enable Travis CI to now run successfully without heavy modifications.